### PR TITLE
get_ssurgo:  temporary fix to get past read_delim bug on one line files 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: FedData
 Title: Functions to Automate Downloading Geospatial Data Available from
     Several Federated Data Sources
-Version: 3.0.0.9000
+Version: 3.0.1.9000
 Date: 2021-09-07
 Authors@R: 
     c(person(given = c("R.", "Kyle"),

--- a/R/SSURGO_FUNCTIONS.R
+++ b/R/SSURGO_FUNCTIONS.R
@@ -386,7 +386,7 @@ get_ssurgo_study_area <- function(template = NULL, area, date, raw.dir) {
   }
 
   file <- download_ssurgo_study_area(area = area, date = date, raw.dir = raw.dir)
-
+  
   utils::unzip(file, exdir = tmpdir)
   suppressMessages({
     mapunits <-
@@ -395,7 +395,7 @@ get_ssurgo_study_area <- function(template = NULL, area, date, raw.dir) {
       ) %>%
       sf::st_make_valid()
   })
-
+  
   # Read in all tables
   tablesData <-
     paste0(tmpdir, "/", area, "/tabular") %>%
@@ -406,6 +406,11 @@ get_ssurgo_study_area <- function(template = NULL, area, date, raw.dir) {
     ) %>%
     purrr::map(
       function(file) {
+        # Hack to bypass one line file bug in readr::read_delim 
+        if(length(readLines(file)) == 1){
+          write("\n", file, append = TRUE)
+        }
+        
         tryCatch(
           return(
             readr::read_delim(file,


### PR DESCRIPTION
Using `get_ssurgo` resulted in a hung R session.  Looks like it was due to a bug in `readr::read_delim` (https://github.com/tidyverse/readr/issues/1309).  This pull request has a temporary fix that adds a new line to the end of any one line files that `get_ssurgo` is reading.  Once the `readr::read_delim` bug is fixed, this should no longer be needed.  

